### PR TITLE
Make UserId nullable in Android bridge

### DIFF
--- a/android/src/main/kotlin/io/castle/flutter/castle_flutter/CastleFlutterPlugin.kt
+++ b/android/src/main/kotlin/io/castle/flutter/castle_flutter/CastleFlutterPlugin.kt
@@ -219,7 +219,7 @@ class CastleFlutterPlugin: FlutterPlugin, MethodCallHandler {
 
   private fun userId(call: MethodCall, result: Result) {
     try {
-      val userId: String = Castle.userId()
+      val userId: String? = Castle.userId()
       result.success(userId)
     } catch (e: Exception) {
       result.error("CastleException", e.localizedMessage, null)


### PR DESCRIPTION
User id can be null so we need to set it to nullable in kotlin flutter bridge